### PR TITLE
Add Copy Selected File Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,22 @@
       "title": "Copy Text Files",
       "description": "Copy text files in current finder",
       "mode": "no-view"
+    },
+    {
+      "name": "copy-selected-file",
+      "title": "Copy Selected File",
+      "description": "Copy text from selected file in current Finder window",
+      "mode": "no-view",
+      "preferences": [
+        {
+          "name": "includeFilePath",
+          "type": "checkbox",
+          "description": "Include the file path in the copied text",
+          "default": false,
+          "label": "Include path",
+          "required": false
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/src/copy-selected-file.ts
+++ b/src/copy-selected-file.ts
@@ -1,0 +1,50 @@
+import { getSelectedFinderItems, Clipboard, showToast, Toast, getPreferenceValues } from "@raycast/api";
+import { promises as fs } from 'fs';
+
+interface Preferences {
+  includeFilePath: boolean
+}
+
+async function getSelectedTextFiles(): Promise<string[]> {
+  try {
+    const files = await getSelectedFinderItems();
+    showToast(Toast.Style.Failure, JSON.stringify(files, null, 4))
+    return files.map(file => file.path)
+  } catch (error) {
+    showToast(Toast.Style.Failure, "📁 Unable to get selected files");
+    return [];
+  }
+}
+
+// 读取纯文本文件内容
+async function readFileContents(files: string[], includeFilePath: boolean): Promise<string> {
+  let content = "";
+  try {
+    for (const file of files) {
+      const fileContent = await fs.readFile(file, "utf-8");
+      if (includeFilePath) {
+        content += `# File path: ${file}\n`;
+      }
+      content += fileContent;
+    }
+    return content;
+  } catch (error) {
+    showToast(Toast.Style.Failure, "📁 Unable to read selected file contents");
+  }
+  return content;
+}
+
+// 命令的主逻辑
+export default async function Command() {
+  const { includeFilePath } = getPreferenceValues<Preferences>();
+  const textFiles = await getSelectedTextFiles();
+  if (textFiles.length === 0) {
+    showToast(Toast.Style.Failure, "📄 No text files selected");
+    return;
+  }
+
+  const mergedContent = await readFileContents(textFiles, includeFilePath);
+  await Clipboard.copy(mergedContent);
+
+  showToast(Toast.Style.Success, "✨ Text files content copied to clipboard", mergedContent);
+}

--- a/src/copy-selected-file.ts
+++ b/src/copy-selected-file.ts
@@ -1,15 +1,15 @@
 import { getSelectedFinderItems, Clipboard, showToast, Toast, getPreferenceValues } from "@raycast/api";
-import { promises as fs } from 'fs';
+import { promises as fs } from "fs";
 
 interface Preferences {
-  includeFilePath: boolean
+  includeFilePath: boolean;
 }
 
 async function getSelectedTextFiles(): Promise<string[]> {
   try {
     const files = await getSelectedFinderItems();
-    showToast(Toast.Style.Failure, JSON.stringify(files, null, 4))
-    return files.map(file => file.path)
+    showToast(Toast.Style.Failure, JSON.stringify(files, null, 4));
+    return files.map((file) => file.path);
   } catch (error) {
     showToast(Toast.Style.Failure, "📁 Unable to get selected files");
     return [];


### PR DESCRIPTION
I thought it would make sense to have a separate command to copy the currently selected file from Finder.

For this use case, I didn't want to include the file path in the copied text by default, so I made that configurable via the Preferences API